### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ appsettings*.json
 wwwroot/js/*.js
 wwwroot/**/*.map
 wwwroot/css/*.css
+.DS_Store


### PR DESCRIPTION
## Pull Request Description

Updated .gitignore to ignore the macOS file system's .DS_Store.

## Type of Change

- [x] Misc change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules